### PR TITLE
Remove float part in system.uptime

### DIFF
--- a/mamonsu/plugins/system/linux/uptime.py
+++ b/mamonsu/plugins/system/linux/uptime.py
@@ -10,7 +10,7 @@ class Uptime(Plugin):
 
     def run(self, zbx):
         uptime = open('/proc/uptime', 'r').read().split(' ')[0]
-        zbx.send('system.uptime[]', float(uptime))
+        zbx.send('system.uptime[]', int(uptime))
 
     def items(self, template):
         return template.item({


### PR DESCRIPTION
We are observing following messages in zabbix-server log
`1107:20160825:104036.610 error reason for "test:system.uptime[]" changed: Received value [10801072.96] is not suitable for value type [Numeric (unsigned)] and data type [Decimal]
` by-design must be decimal.
We have "Numeric Unsigned" in template.