### PR TITLE
use invoke-rc.d in logrotate postrotate action

### DIFF
--- a/packaging/debian/logrotate
+++ b/packaging/debian/logrotate
@@ -7,6 +7,6 @@
     create 0640 mamonsu mamonsu
     sharedscripts
     postrotate
-        [ -e /var/run/mamonsu/mamonsu.pid ] && /etc/init.d/mamonsu restart >/dev/null
+        [ -e /var/run/mamonsu/mamonsu.pid ] && invoke-rc.d mamonsu restart > /dev/null
     endscript
 }


### PR DESCRIPTION
invoke-rc.d is able to handle SysV init scripts and systemd,
thus it makes sense to be Debian policy conform and use that,
instead of forcing the usage of the init script.