### PR TITLE
remove usage of echo -e from Debian init script

### DIFF
--- a/packaging/debian/init
+++ b/packaging/debian/init
@@ -36,7 +36,7 @@ start() {
   fi
   echo -n 'Starting service' >&2
   su -c "$COMMAND" $RUNAS -s /bin/sh &
-  echo -e '\t\tOK' >&2
+  echo '\t\tOK' >&2
 }
 
 stop() {
@@ -46,7 +46,7 @@ stop() {
   fi
   echo -n 'Stopping service' >&2
   kill -15 $(cat "$PIDFILE") && rm -f "$PIDFILE"
-  echo -e '\t\tOK' >&2
+  echo '\t\tOK' >&2
 }
 
 status() {


### PR DESCRIPTION
The debian default "/bin/sh" is dash. The build in echo
implementation in dash does not support "-e", so it echos
a verbatim "-e" but the \t are none the less parsed and
represented as a tabulator.
In case someone changed "/bin/sh" to a none default shell,
it might result in varbatim "\t" in the output.

Alternative would be to call "/bin/echo -e" explicitly.