### PR TITLE
Rename query to transaction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -220,7 +220,7 @@ Metrics:  PostgreSQL
     'PostgreSQL locks: Locks from application': pgsql.pg_locks[sharerowexclusive]
     'PostgreSQL locks: Locks from application or some operation on system catalogs': pgsql.pg_locks[exclusive]
     'PostgreSQL locks: ALTER TABLE, DROP TABLE, TRUNCATE, REINDEX, CLUSTER, VACUUM FULL, LOCK TABLE': pgsql.pg_locks[accessexclusive]
-    'PostgreSQL oldest query running time': pgsql.oldest[query_time]
+    'PostgreSQL oldest transaction running time': pgsql.oldest[transaction_time]
     'PostgreSQL age of oldest xid': pgsql.oldest[xid_age]
     'PostgreSQL waits: Lightweight locks': pgsql.all_lock[lwlock]
     'PostgreSQL waits: Heavyweight locks': pgsql.all_lock[hwlock]

--- a/mamonsu/plugins/pgsql/oldest.py
+++ b/mamonsu/plugins/pgsql/oldest.py
@@ -28,7 +28,7 @@ select public.mamonsu_get_oldest_query();
 
     DEFAULT_CONFIG = {
         'max_xid_age': str(5000 * 60 * 60),
-        'max_query_time': str(5 * 60 * 60)
+        'max_transaction_time': str(5 * 60 * 60)
     }
 
     def run(self, zbx):
@@ -40,13 +40,13 @@ select public.mamonsu_get_oldest_query();
             query = Pooler.query(self.OldestQuerySql)[0][0]
 
         zbx.send('pgsql.oldest[xid_age]', xid)
-        zbx.send('pgsql.oldest[query_time]', query)
+        zbx.send('pgsql.oldest[transaction_time]', query)
 
     def graphs(self, template):
         result = template.graph({
-            'name': 'PostgreSQL oldest query running time',
+            'name': 'PostgreSQL oldest transaction running time',
             'items': [{
-                'key': 'pgsql.oldest[query_time]',
+                'key': 'pgsql.oldest[transaction_time]',
                 'color': '00CC00'
             }]
         })
@@ -65,8 +65,8 @@ select public.mamonsu_get_oldest_query();
             'name': 'PostgreSQL: age of oldest xid',
             'value_type': Plugin.VALUE_TYPE.numeric_unsigned
         }) + template.item({
-            'key': 'pgsql.oldest[query_time]',
-            'name': 'PostgreSQL: oldest query running time in sec',
+            'key': 'pgsql.oldest[transaction_time]',
+            'name': 'PostgreSQL: oldest transaction running time in sec',
             'units': Plugin.UNITS.s
         })
 
@@ -76,7 +76,7 @@ select public.mamonsu_get_oldest_query();
             'expression': '{#TEMPLATE:pgsql.oldest[xid_age]'
             '.last()}&gt;' + self.plugin_config('max_xid_age')
         }) + template.trigger({
-            'name': 'PostgreSQL query running is too old on {HOSTNAME}',
-            'expression': '{#TEMPLATE:pgsql.oldest[query_time]'
-            '.last()}&gt;' + self.plugin_config('max_query_time')
+            'name': 'PostgreSQL transaction running is too old on {HOSTNAME}',
+            'expression': '{#TEMPLATE:pgsql.oldest[transaction_time]'
+            '.last()}&gt;' + self.plugin_config('max_transaction_time')
         })


### PR DESCRIPTION
xact_start	— это время начала текущей транзакции (transaction), а не запроса (query).