### PR TITLE
Exclude replication sessions from activity statistics

### DIFF
--- a/mamonsu/plugins/pgsql/oldest.py
+++ b/mamonsu/plugins/pgsql/oldest.py
@@ -17,14 +17,17 @@ select public.mamonsu_get_oldest_xid();
 """
 
     OldestQuerySql = """
-select
-    extract(epoch from max(now() - xact_start))
-from pg_catalog.pg_stat_activity 
-where 
-    pid not in (select pid from pg_stat_replication)
-    AND pid <> pg_backend_pid() 
-    AND query not ilike '%VACUUM%' 
-    HAVING extract(epoch from max(now() - xact_start))>0;
+SELECT 
+  CASE WHEN extract(epoch from max(now() - xact_start)) IS NOT null 
+    THEN extract(epoch from max(now() - xact_start)) 
+    ELSE 0 
+  END 
+FROM pg_catalog.pg_stat_activity 
+WHERE 
+  pid NOT IN(select pid from pg_stat_replication) AND 
+  pid <> pg_backend_pid() AND 
+  query NOT ilike '%%VACUUM%%' 
+HAVING extract(epoch from max(now() - xact_start))>0;
 """
 
     OldestQuerySql_bootstrap = """

--- a/mamonsu/plugins/pgsql/oldest.py
+++ b/mamonsu/plugins/pgsql/oldest.py
@@ -19,7 +19,7 @@ select public.mamonsu_get_oldest_xid();
     OldestQuerySql = """
 select
     extract(epoch from max(now() - xact_start))
-from pg_catalog.pg_stat_activity;
+from pg_catalog.pg_stat_activity where pid not in (select pid from pg_stat_replication);
 """
 
     OldestQuerySql_bootstrap = """

--- a/mamonsu/plugins/pgsql/oldest.py
+++ b/mamonsu/plugins/pgsql/oldest.py
@@ -19,7 +19,12 @@ select public.mamonsu_get_oldest_xid();
     OldestQuerySql = """
 select
     extract(epoch from max(now() - xact_start))
-from pg_catalog.pg_stat_activity where pid not in (select pid from pg_stat_replication);
+from pg_catalog.pg_stat_activity 
+where 
+    pid not in (select pid from pg_stat_replication)
+    AND pid <> pg_backend_pid() 
+    AND query not ilike '%VACUUM%' 
+    HAVING extract(epoch from max(now() - xact_start))>0;
 """
 
     OldestQuerySql_bootstrap = """

--- a/mamonsu/plugins/pgsql/oldest.py
+++ b/mamonsu/plugins/pgsql/oldest.py
@@ -19,6 +19,7 @@ select public.mamonsu_get_oldest_xid();
     OldestQuerySql = """
 SELECT 
   CASE WHEN extract(epoch from max(now() - xact_start)) IS NOT null 
+        AND extract(epoch from max(now() - xact_start))>0
     THEN extract(epoch from max(now() - xact_start)) 
     ELSE 0 
   END 
@@ -26,8 +27,7 @@ FROM pg_catalog.pg_stat_activity
 WHERE 
   pid NOT IN(select pid from pg_stat_replication) AND 
   pid <> pg_backend_pid() AND 
-  query NOT ilike '%%VACUUM%%' 
-HAVING extract(epoch from max(now() - xact_start))>0;
+  query NOT ilike '%%VACUUM%%';
 """
 
     OldestQuerySql_bootstrap = """

--- a/mamonsu/tools/bootstrap/sql.py
+++ b/mamonsu/tools/bootstrap/sql.py
@@ -70,7 +70,11 @@ RETURNS DOUBLE PRECISION AS $$
     SELECT
         extract(epoch from max(now() - xact_start))
     FROM pg_catalog.pg_stat_activity
-    WHERE pid not in (select pid from pg_stat_replication)
+    WHERE 
+        pid not in (select pid from pg_stat_replication)
+        AND pid <> pg_backend_pid() 
+        AND query not ilike '%VACUUM%' 
+        HAVING extract(epoch from max(now() - xact_start))>0
 $$ LANGUAGE SQL SECURITY DEFINER;
 
 CREATE OR REPLACE FUNCTION public.mamonsu_count_{3}_files()

--- a/mamonsu/tools/bootstrap/sql.py
+++ b/mamonsu/tools/bootstrap/sql.py
@@ -69,6 +69,7 @@ CREATE or REPLACE FUNCTION public.mamonsu_get_oldest_query()
 RETURNS DOUBLE PRECISION AS $$
     SELECT 
         CASE WHEN extract(epoch from max(now() - xact_start)) IS NOT null 
+              AND extract(epoch from max(now() - xact_start))>0
             THEN extract(epoch from max(now() - xact_start)) 
             ELSE 0 
         END 
@@ -76,8 +77,7 @@ RETURNS DOUBLE PRECISION AS $$
     WHERE 
         pid NOT IN(select pid from pg_stat_replication) AND 
         pid <> pg_backend_pid() AND 
-        query NOT ilike '%%VACUUM%%' 
-    HAVING extract(epoch from max(now() - xact_start))>0
+        query NOT ilike '%%VACUUM%%'
 $$ LANGUAGE SQL SECURITY DEFINER;
 
 CREATE OR REPLACE FUNCTION public.mamonsu_count_{3}_files()

--- a/mamonsu/tools/bootstrap/sql.py
+++ b/mamonsu/tools/bootstrap/sql.py
@@ -67,14 +67,17 @@ $$ LANGUAGE SQL SECURITY DEFINER;
 
 CREATE or REPLACE FUNCTION public.mamonsu_get_oldest_query()
 RETURNS DOUBLE PRECISION AS $$
-    SELECT
-        extract(epoch from max(now() - xact_start))
-    FROM pg_catalog.pg_stat_activity
+    SELECT 
+        CASE WHEN extract(epoch from max(now() - xact_start)) IS NOT null 
+            THEN extract(epoch from max(now() - xact_start)) 
+            ELSE 0 
+        END 
+    FROM pg_catalog.pg_stat_activity 
     WHERE 
-        pid not in (select pid from pg_stat_replication)
-        AND pid <> pg_backend_pid() 
-        AND query not ilike '%VACUUM%' 
-        HAVING extract(epoch from max(now() - xact_start))>0
+        pid NOT IN(select pid from pg_stat_replication) AND 
+        pid <> pg_backend_pid() AND 
+        query NOT ilike '%%VACUUM%%' 
+    HAVING extract(epoch from max(now() - xact_start))>0
 $$ LANGUAGE SQL SECURITY DEFINER;
 
 CREATE OR REPLACE FUNCTION public.mamonsu_count_{3}_files()

--- a/mamonsu/tools/bootstrap/sql.py
+++ b/mamonsu/tools/bootstrap/sql.py
@@ -70,6 +70,7 @@ RETURNS DOUBLE PRECISION AS $$
     SELECT
         extract(epoch from max(now() - xact_start))
     FROM pg_catalog.pg_stat_activity
+    WHERE pid not in (select pid from pg_stat_replication)
 $$ LANGUAGE SQL SECURITY DEFINER;
 
 CREATE OR REPLACE FUNCTION public.mamonsu_count_{3}_files()


### PR DESCRIPTION
В запрос попадают сессии репликаций, которые дают шум в виде ложных данных и алертов. Например, на PostgreSQL 10 это выглядит так (на PostgreSQL 9 еще нет некоторых столбцов в этих вьюшках):
```sql
postgres=# select backend_start, state_change, backend_type  from pg_stat_activity where backend_type='walsender';
         backend_start         |         state_change          | backend_type
-------------------------------+-------------------------------+--------------
 2019-03-29 12:07:34.025271+03 | 2019-03-29 12:07:34.040316+03 | walsender
 2019-03-26 11:32:48.867826+03 | 2019-03-26 11:32:48.879615+03 | walsender
 2019-03-26 11:28:10.609826+03 | 2019-03-26 11:28:10.623686+03 | walsender
 2019-03-26 11:34:29.433586+03 | 2019-03-26 11:34:29.446974+03 | walsender
 2019-03-19 23:52:19.59697+03  | 2019-03-19 23:52:19.603275+03 | walsender
 2019-03-25 19:25:27.418058+03 | 2019-03-25 19:25:27.429683+03 | walsender
 2019-03-25 19:50:47.664041+03 | 2019-03-25 19:50:47.677882+03 | walsender
 2019-03-26 11:36:47.384509+03 | 2019-03-26 11:36:47.401471+03 | walsender
 2019-03-26 11:38:46.560473+03 | 2019-03-26 11:38:46.571872+03 | walsender
 2019-03-26 11:30:51.671917+03 | 2019-03-26 11:30:51.682174+03 | walsender
 2019-03-26 11:40:12.640147+03 | 2019-03-26 11:40:12.652937+03 | walsender
 2019-03-25 19:47:01.703121+03 | 2019-03-25 19:47:01.716741+03 | walsender
(12 rows)

postgres=# select version();
                                                 version
---------------------------------------------------------------------------------------------------------
 PostgreSQL 10.7 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-36), 64-bit
```