### PR TITLE
Fix PostgreSQL Ping time format

### DIFF
--- a/mamonsu/plugins/pgsql/health.py
+++ b/mamonsu/plugins/pgsql/health.py
@@ -13,7 +13,7 @@ class PgHealth(Plugin):
 
         start_time = time.time()
         Pooler.query('select 1 as health')
-        zbx.send('pgsql.ping[]', (time.time() - start_time) * 100)
+        zbx.send('pgsql.ping[]', (time.time() - start_time) * 1000)
 
         result = Pooler.query("select \
             date_part('epoch', now() - pg_postmaster_start_time())")


### PR DESCRIPTION
В документации к Python указано, что [time.time()](https://docs.python.org/2.7/library/time.html#time.time) возвращает значение в epoch (секунды с плавающей точкой, два знака после запятой). Отсюда делаю вывод, что вычисление ((time.time() - start_time) * 100) возвращает время в [сантисекундах](https://ru.wikipedia.org/wiki/Секунда#Кратные_и_дольные_единицы), а не в миллисекундах (как указано в [шаблоне](https://github.com/postgrespro/mamonsu/blob/master/packaging/conf/template.xml#L2643)).