### PR TITLE
Update Debian version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 before_install:
 - docker pull centos:6
 - docker pull centos:7
-- docker pull debian:7
+- docker pull debian:9
 
 script:
 - make test

--- a/Makefile.tests
+++ b/Makefile.tests
@@ -2,7 +2,7 @@ test: run_builds run_functional_tests
 
 run_builds:
 	docker run --rm -v "$(WORKDIR)":/var/tmp centos:7 /bin/bash -ex "/var/tmp/tests/build_rpm.sh"
-	docker run --rm -v "$(WORKDIR)":/var/tmp debian:7 /bin/bash -ex "/var/tmp/tests/build_deb.sh"
+	docker run --rm -v "$(WORKDIR)":/var/tmp debian:9 /bin/bash -ex "/var/tmp/tests/build_deb.sh"
 
 run_functional_tests:
 	docker run --rm -v "$(WORKDIR)":/var/tmp centos:6 /bin/bash -ex "/var/tmp/tests/check.sh"


### PR DESCRIPTION
Debian 7 был [заменён](https://www.debian.org/releases/wheezy/) на Debian 8 (jessie), а Debian 8 — [заменен](https://www.debian.org/releases/jessie/) на Debian 9 (stretch). Не уверен, есть ли еще смысл тестить на устаревших сборках.