### PR TITLE
Plugins/system/linux/disk_sizes

### DIFF
--- a/mamonsu/plugins/system/linux/disk_sizes.py
+++ b/mamonsu/plugins/system/linux/disk_sizes.py
@@ -15,8 +15,8 @@ class DiskSizes(Plugin):
         'pstore', 'devtmpfs', 'autofs',
         'cgroup', 'configfs', 'devpts',
         'efivarfs', 'fusectl', 'fuse.gvfsd-fuse',
-        'hugetlbfs', 'mqueue',
-        'nfsd', 'proc', 'pstore',
+        'hugetlbfs', 'mqueue', 'binfmt_misc',
+        'nfsd', 'proc', 'pstore', 'selinuxfs'
         'rpc_pipefs', 'securityfs', 'sysfs',
         'nsfs', 'tmpfs', 'tracefs']
 


### PR DESCRIPTION
Exclude from FS types:
- [binfmt_misc](https://en.wikipedia.org/wiki/Binfmt_misc)
- [selinuxfs](http://selinuxproject.org/page/NB_LSM#SELinux_Filesystem)