### PR TITLE
Fix 'noneType instead of int'

### DIFF
--- a/mamonsu/plugins/pgsql/instance.py
+++ b/mamonsu/plugins/pgsql/instance.py
@@ -70,7 +70,7 @@ class Instance(Plugin):
         if Pooler.server_version_greater('12.0'):
             all_items = self.Items + self.Items_pg_12
 
-        params = ['sum({0}) as {0}'.format(x[0]) for x in all_items]
+        params = ['sum(COALESCE({0}, 0)) as {0}'.format(x[0]) for x in all_items]
         result = Pooler.query('select {0} from \
             pg_catalog.pg_stat_database'.format(
             ', '.join(params)))


### PR DESCRIPTION
Request:
"select sum(xact_commit) as xact_commit, sum(blks_hit) as blks_hit, sum(blks_read) as blks_read, sum(conflicts) as conflicts, sum(deadlocks) as deadlocks, sum(xact_rollback) as xact_rollback, sum(temp_bytes) as temp_bytes, sum(temp_files) as temp_files, sum(tup_deleted) as tup_deleted, sum(tup_fetched) as tup_fetched, sum(tup_inserted) as tup_inserted, sum(tup_returned) as tup_returned, sum(tup_updated) as tup_updated, sum(checksum_failures) as checksum_failures from pg_catalog.pg_stat_database"

causes error:
"INSTANCE#011-#011catch error: int() argument must be a string or a number, not 'NoneType'"

because in my working database the field 'checksum_failures' is NULL.

Added a function returning '0' if the value is 'NULL'