### PR TITLE
Неверный параметра фильтра правила обнаружения

### DIFF
--- a/mamonsu/lib/zbx_template.py
+++ b/mamonsu/lib/zbx_template.py
@@ -101,7 +101,7 @@ class ZbxTemplate(object):
         ('snmpv3_securityname', None), ('snmpv3_securitylevel', 0),
         ('snmpv3_authprotocol', 0), ('snmpv3_authpassphrase', None),
         ('snmpv3_privprotocol', 0), ('snmpv3_privpassphrase', None),
-        ('delay_flex', None), ('params', None),
+        ('delay_flex', None), ('params', 8),
         ('ipmi_sensor', None), ('authtype', 0),
         ('username', None), ('password', None), ('publickey', None),
         ('privatekey', None), ('port', None), ('lifetime', 7),


### PR DESCRIPTION
Zabbix 4 не импортировал шаблон, т.к. в фильтрах правил обнаружения указан неверный параметр. Точнее, он не определён, что для заббикса является ошибкой.
Поставил восьмой параметр, что является значением 'соответствует'.