### PR TITLE
fix: prevent Instance plugin Items list mutation on each run() cycle

### DIFF
--- a/mamonsu/plugins/pgsql/instance.py
+++ b/mamonsu/plugins/pgsql/instance.py
@@ -95,7 +95,7 @@ class Instance(Plugin):
         "tuples": "PostgreSQL Instance: Tuples"}
 
     def run(self, zbx):
-        all_items = self.Items
+        all_items = self.Items.copy()
         if Pooler.server_version_greater("12.0"):
             all_items += self.Items_pg_12
         if Pooler.server_version_greater("18.0"):
@@ -213,7 +213,7 @@ class Instance(Plugin):
 
     def keys_and_queries(self, template_zabbix):
         result = []
-        all_items = self.Items
+        all_items = self.Items.copy()
         if Pooler.server_version_greater("12.0"):
             all_items += self.Items_pg_12
         if Pooler.server_version_greater("18.0"):


### PR DESCRIPTION
Методы `run()` и `keys_and_queries()` в instance.py используют `all_items = self.Items`, что создаёт ссылку на список класса, а затем `+= self.Items_pg_12` мутирует его на месте через `list.iadd`. Из-за этого `self.Items` постоянно растёт на `len(Items_pg_12) + len(Items_pg_18)` элементов при каждом цикле сбора, вызывая утечку памяти.

Исправление: использовать `self.Items.copy()` для создания нового списка на каждом вызове — аналогично фиксу плагина Statements в v3.5.2 (#187).

Исправляет #232