### PR TITLE
fix(cfs): exclude non-physical relations

### DIFF
--- a/mamonsu/plugins/pgsql/cfs.py
+++ b/mamonsu/plugins/pgsql/cfs.py
@@ -14,6 +14,7 @@ class Cfs(Plugin):
     }
 
     query_cfs_compressed_ratio = """
+    WITH cfs_data AS (
     SELECT
         n.nspname || '.' || c.relname AS table_name,
         cfs_compression_ratio(c.oid::regclass) AS ratio,
@@ -22,8 +23,7 @@ class Cfs(Plugin):
         pg_catalog.pg_class AS c
         LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
     WHERE c.reltablespace IN (SELECT oid FROM pg_catalog.pg_tablespace WHERE spcoptions::text ~ 'compression')
-        AND c.relkind IN ('r','v','m','S','f','p','')
-        AND cfs_compression_ratio(c.oid::regclass) <> 'NaN'
+        AND c.relkind IN ('r','m','S') -- only relkinds with physical storage
     
     UNION ALL
     
@@ -36,7 +36,8 @@ class Cfs(Plugin):
         LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
     WHERE c.reltablespace IN (SELECT oid FROM pg_catalog.pg_tablespace WHERE spcoptions::text ~ 'compression')
         AND c.relkind = 'i'
-        AND cfs_compression_ratio(c.oid::regclass) <> 'NaN';
+    -- subquery + outer NaN filter prevent planner from calling cfs_compression_ratio() before reltablespace/relkind filters
+    ) SELECT table_name, ratio, compressed_size FROM cfs_data WHERE ratio <> 'NaN';
     """
 
     query_cfs_activity = """

--- a/mamonsu/plugins/pgsql/cfs.py
+++ b/mamonsu/plugins/pgsql/cfs.py
@@ -22,8 +22,10 @@ class Cfs(Plugin):
     FROM
         pg_catalog.pg_class AS c
         LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-    WHERE c.reltablespace IN (SELECT oid FROM pg_catalog.pg_tablespace WHERE spcoptions::text ~ 'compression')
-        AND c.relkind IN ('r','m','S') -- only relkinds with physical storage
+    WHERE c.reltablespace IN (
+        SELECT oid FROM pg_catalog.pg_tablespace 
+        WHERE spcoptions::text ~ 'compression' AND spcname NOT IN ('pg_default', 'pg_global')
+    ) AND c.relkind IN ('r','m','S') -- only relkinds with physical storage
     
     UNION ALL
     
@@ -34,8 +36,10 @@ class Cfs(Plugin):
     FROM
         pg_catalog.pg_class AS c
         LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-    WHERE c.reltablespace IN (SELECT oid FROM pg_catalog.pg_tablespace WHERE spcoptions::text ~ 'compression')
-        AND c.relkind = 'i'
+    WHERE c.reltablespace IN (
+        SELECT oid FROM pg_catalog.pg_tablespace
+        WHERE spcoptions::text ~ 'compression' AND spcname NOT IN ('pg_default', 'pg_global')
+    ) AND c.relkind = 'i'
     -- subquery + outer NaN filter prevent planner from calling cfs_compression_ratio() before reltablespace/relkind filters
     ) SELECT table_name, ratio, compressed_size FROM cfs_data WHERE ratio <> 'NaN';
     """

--- a/mamonsu/plugins/pgsql/cfs.py
+++ b/mamonsu/plugins/pgsql/cfs.py
@@ -14,7 +14,7 @@ class Cfs(Plugin):
     }
 
     query_cfs_compressed_ratio = """
-    WITH cfs_data AS (
+    WITH cfs_data AS MATERIALIZED (
     SELECT
         n.nspname || '.' || c.relname AS table_name,
         cfs_compression_ratio(c.oid::regclass) AS ratio,


### PR DESCRIPTION
cfs_compression_ratio() in PG Pro EE 16.13/18 leaks relcache for relations without physical CFS storage.

Early return without relation_close() produces WARNING on every call.

To mitigate that, relkind in CFS query is restricted to ('r','m','S'), and the query is wrapped in a subquery, so the planner calls cfs_compression_ratio only on filtered rows.